### PR TITLE
Add this_node IP address

### DIFF
--- a/hiera/common.yaml
+++ b/hiera/common.yaml
@@ -1,5 +1,9 @@
 ---
 # Hosts & IPs
+# This should automatically populate from Puppet, but if not, it
+# can be manually defined here:
+this_node: &this_node "%{::ipaddress}"
+
 # Edit the following line to set the IP address of your Control node.
 # This is the node where the API services, mysql, and RabbitMQ run.
 control_node: &control_node '127.0.0.1'
@@ -327,7 +331,7 @@ neutron::plugins::ml2::tenant_network_types:
 neutron::plugins::ml2::mechanism_drivers:
  - 'openvswitch'
 neutron::agents::ml2::ovs::enable_tunneling: true
-neutron::agents::ml2::ovs::local_ip: '127.0.0.1'
+neutron::agents::ml2::ovs::local_ip: *this_node
 neutron::agents::ml2::ovs::tunnel_types:
  - 'vxlan'
 neutron::service_plugins:


### PR DESCRIPTION
In order for the vxlan tunnel to be set up, the ovs local_ip ovs variable has 
to be set for each node's local address. Grab this automatically from the
Puppet fact and set it.